### PR TITLE
[스택/큐]: 프린터, Task Scheduler, Valid Parenthese

### DIFF
--- a/arori/stack&queue/Printer.js
+++ b/arori/stack&queue/Printer.js
@@ -1,0 +1,31 @@
+function solution(priorities, location) {
+  let count = 0;
+  let maxIndex = 0;
+  const visitiedNode = [];
+  while (count !== priorities.length) {
+    // 시작 인덱스는 마지막 탐색 인덱스 혹은 0
+    const startedIndex = maxIndex;
+    // 매 1번의 순회에 사용하는 변수 초기화
+    let i = startedIndex; // 현재 인덱스
+    let max = 0; // 1번의 순회에서 제일 큰 값
+    maxIndex = -1; // 1번의 순회에서 제일 큰 값이 있는 인덱스
+
+    do {
+      const isVisitied = visitiedNode[i];
+
+      // 방문한 노드는 제외 & 최대값이면 임시 변수에 관련 정보 저장
+      if (!isVisitied && priorities[i] > max) {
+        max = priorities[i];
+        maxIndex = i;
+      }
+      i = i === priorities.length - 1 ? 0 : i + 1;
+    } while (i !== startedIndex);
+    // 한바퀴 다 돌았으면 종료
+
+    count++;
+    visitiedNode[maxIndex] = true;
+    if (maxIndex === location) return count;
+  }
+
+  return count;
+}

--- a/arori/stack&queue/TaskScheduler.js
+++ b/arori/stack&queue/TaskScheduler.js
@@ -1,0 +1,58 @@
+/**
+ * @param {character[]} tasks
+ * @param {number} n
+ * @return {number}
+ */
+var leastInterval = function (tasks, n) {
+  let count = 0;
+  const map = {};
+  if (n === 0) return tasks.length;
+  tasks.forEach((item) => {
+    const num = map[item];
+    map[item] = num ? num + 1 : 1;
+  });
+  const values = Object.values(map);
+  values.sort((a, b) => a - b);
+  const pq = new PriorityQ(values);
+
+  while (!pq.isEmpty()) {
+    const append = [];
+    for (let i = 0; i <= n; i++) {
+      const value = pq.dequeue();
+      if (append.length === 0 && value === null) return count;
+      if (value > 1) {
+        append.push(value - 1);
+      }
+      count++;
+    }
+    append.forEach((item) => {
+      pq.enqueue(item);
+    });
+  }
+  return count;
+};
+
+class PriorityQ {
+  constructor(array) {
+    this.data = array || [];
+  }
+  enqueue(value) {
+    this.data.push(value);
+  }
+  dequeue() {
+    if (this.isEmpty()) return null;
+    let highestIndex = 0;
+    let highest = 0;
+    this.data.forEach((item, index) => {
+      if (highest < item) {
+        highest = item;
+        highestIndex = index;
+      }
+    });
+    this.data.splice(highestIndex, 1);
+    return highest;
+  }
+  isEmpty() {
+    return !this.data.length;
+  }
+}

--- a/arori/stack&queue/ValidParentheses.js
+++ b/arori/stack&queue/ValidParentheses.js
@@ -1,0 +1,26 @@
+/**
+ * @param {string} s
+ * @return {boolean}
+ */
+var isValid = function (s) {
+  let array = [];
+  const map = {
+    "(": ")",
+    "[": "]",
+    "{": "}",
+  };
+  if (s.length % 2) return false;
+  for (let i = 0; i < s.length; i++) {
+    if (map[s[i]]) {
+      array.push(s[i]);
+    } else {
+      if (array.length <= 0) return false;
+      const parenthesis = array.pop();
+      if (map[parenthesis] !== s[i]) {
+        return false;
+      }
+    }
+  }
+
+  return !array.length;
+};


### PR DESCRIPTION
## 문제 링크
https://leetcode.com/problems/valid-parentheses/
https://leetcode.com/problems/task-scheduler/
https://programmers.co.kr/learn/courses/30/lessons/42587
### 개념 정리 링크
https://www.notion.so/3bacd41726e1493ab0abf776224a0fe0
## 풀이 방식
### Valid Parentheses
1. 괄호 쌍을 매핑한 객체 생성
2. 총 괄호 갯수가 짝수가 아니면 쌍이 안맞으므로 early return
3. 그 외라면 문자열을 순회한다
    1. 열리는 괄호면 Stack에 넣고, 닫히는 괄호면 Stack에서 꺼내고, 맞는 쌍인지 확인한다
    2. 맞는 쌍이면 계속 순회하고, 틀린 쌍이면 유효하지않으므로 `return false`
4. 순회 완료 후,  Stack에 남은 아이템이있으면 열린 괄호의 쌍이 맞지 않으므로 `return false`, 아니라면 `return true`
### Task Scheduler
1. 한 번 순회하면서 각 테스크의 크기를 매핑한 객체 생성
2. 테스크 이름이 빠지고 테스크 크기를 담은 배열 생성
3. 해당 배열을 내림차순 소트 
4. 해당 배열을 우선순위 큐(PQ)에 넣고, 큐가 빌때까지 n+1 만큼 순회를 반복 

**[느낀점 / 아쉬운 점]**
- Priority Queue는 주로 힙으로 개발한다고 하던데, 아직 힙을 정리 전이라 위키피디아에 있던 단순한 방법으로 개발해봄. JS는 빌트인 PQ가 없어서..
- 돌아는 가지만 복잡한 풀이로 풀었는데, 디스커션에서 제목보고 O(n)으로 풀수 있다는걸 알았다. 
  -  기회가 되면 다시 풀려고 소스코드는 안봤는데 PQ로 풀이한 부분을 수학적으로 풀지 않았을까 추측중.. 
### 프린터
1. 우선순위 배열만큼 카운트가 올라갔을 때까지 순회
1. 마지막 탐색 인덱스나, 0(첫 시작)을 시작인덱스로 하여 순회 시작
1. 다시 시작 인덱스에 도착할 때까지 방문하지 않은 배열의 요소중 가장 큰 값을 가진 요소를 찾기
1. 한바퀴를 다 돌고나면 가장 큰 요소를 방문한 요소로 체크하고 카운트 증가
1. `location` 값과 같으면 순회를 종료하고 리턴 

**[느낀 점 / 아쉬운 점]**
- 다풀고나서 지한님 코드를 봤는데, PQ로 어떻게 같은 우선순위일 때의 순서가 유지되는지 이해 못했음.. ㅠㅠ 
- 큐를 사용해서 풀수 있는 좋은 방법이 안떠올랐고, 문제를 그대로 빼서 다시 넣는 방식이면 큐안쓰고 배열 순회하는게 연산을 덜 할 것 같아서 큐를 안썼음. 큐를 쓰는 문젠데 ㅠㅠ 

