### PR TITLE
[add] 문제풀이 - BFS/해시테이블: Cousins in Binary Tree, Two Sum, Group Anagrams

### DIFF
--- a/arori/graph/CousinsInBinaryTree.js
+++ b/arori/graph/CousinsInBinaryTree.js
@@ -1,0 +1,41 @@
+/**
+ * Definition for a binary tree node.
+ * function TreeNode(val, left, right) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.left = (left===undefined ? null : left)
+ *     this.right = (right===undefined ? null : right)
+ * }
+ */
+/**
+ * @param {TreeNode} root
+ * @param {number} x
+ * @param {number} y
+ * @return {boolean}
+ */
+var isCousins = function (root, x, y) {
+  if (root.val === x || root.val === y) return false;
+
+  let xParent = 0;
+  let yParent = 0;
+  const queue = [root, null];
+
+  while (queue.length) {
+    node = queue.shift();
+    if (node === null) {// 한 줄 완료됨
+      if (xParent || yParent) return false;
+      queue.push(null);
+      continue;
+    }
+
+    if (node.left) {
+      queue.push(node.left);
+      if (node.left.val === x) xParent = node.val;
+      if (node.left.val === y) yParent = node.val;
+    }
+    if (node.right) {
+      queue.push(node.right);
+      if (node.right.val === x) xParent = node.val;
+    }
+    if (xParent && yParent) return xParent !== yParent;
+  }
+};

--- a/arori/hash/GroupAnagrams.js
+++ b/arori/hash/GroupAnagrams.js
@@ -1,0 +1,21 @@
+/**
+ * @param {string[]} strs
+ * @return {string[][]}
+ */
+var groupAnagrams = function (strs) {
+  const strsMap = {};
+  for (str of strs) {
+    const map = new Array(26).fill(0);
+    for (let i = 0; i < str.length; i++) {
+      const key = str.charCodeAt(i) - 97;
+      map[key]++;
+    }
+    const key = map.reduce((acc, cur, idx) => {
+      const alphabet = String.fromCharCode(idx + 97);
+      return cur ? acc + alphabet + cur : acc;
+    }, "");
+
+    strsMap[key] ? strsMap[key].push(str) : (strsMap[key] = [str]);
+  }
+  return Object.values(strsMap);
+};

--- a/arori/hash/TwoSum.js
+++ b/arori/hash/TwoSum.js
@@ -1,0 +1,15 @@
+/**
+ * @param {number[]} nums
+ * @param {number} target
+ * @return {number[]}
+ */
+var twoSum = function (nums, target) {
+  const map = {};
+  for (let i = 0; i < nums.length; i++) {
+    const j = map[target - nums[i]];
+    if (typeof j === "number" && i !== j) {
+      return [i, j];
+    }
+    map[nums[i]] = i;
+  }
+};


### PR DESCRIPTION
## 문제 링크
https://leetcode.com/problems/cousins-in-binary-tree/
https://leetcode.com/problems/two-sum/
https://leetcode.com/problems/group-anagrams/

## 풀이 방식
### Cousins in Binary Tree
- x나 y가 root면 cousin일 수 없으므로 early return
- queue 에 root와 null 추가
  - null은 한 줄이 완료됨을 뜻하며, 같은 depth인지 확인하는데 사용 
-  queue가 빌때까지 반복하면서 순회
  - queue에서 꺼내온 값이 null이면 한 줄이 완료 되었다는 뜻이므로, x나 y를 찾았는지 확인하고 둘중 하나를 찾았다면 같은 줄 내에 없었다는 뜻이므로 사촌이아니므로 false 리턴. 또한, 한줄이 끝났다는 것은 다음줄이 다 queue에 들어와있다는 것을 의미하므로 한 줄이 다시 끝났음을 의미하는 null을 queue에 추가 
  -  null이 아니라면 현재 노드의 좌, 우가 x나 y인지 확인. 값이 있다면 찾았음을 나타냄과 동시에 부모가 무엇인지 확인용으로 xParent, 혹은 yParent 에 값을 저장
  - 만약 x, y를 둘다 찾았을 때, xParent와 yParent가 같다면 사촌이아니라 형제이므로 같은지 여부를 return 
### Two Sum
- map 객체 생성
- 전체 배열 순회
  - 현재 탐색중인 값에 더해서 결과값을 도출할 수 있는 다른 값이 map 객체에 있는지 확인
  - 있는 경우 바로 return 
  - 없으면 현재 값을 key로 하고, 원 배열에서의 index를 value로 하여, map 객체에 저장
### Group Anagrams
- 문자열의 배열을 다 순회하면서 각 문자열의 문자 빈도수를 확인 
- 해당 빈도수를 가지고 해시 값을 만들고 이를 키로 하여  map 객체에 저장 
  - 키 값이 없으면 해당 문자열을 포함한 배열을, 이미 같은 키 값을 가지고 있는 경우 기존 배열에 문자열 추가 