### PR TITLE
[BFS/Hash-table] Cousins in Binary Tree, Group Anagrams, Two Sum

### DIFF
--- a/sujin-park/bfs-hash-table/cousinsInBinaryTree.js
+++ b/sujin-park/bfs-hash-table/cousinsInBinaryTree.js
@@ -1,0 +1,51 @@
+/**
+ * Definition for a binary tree node.
+ * function TreeNode(val, left, right) {
+ *     this.val = (val===undefined ? 0 : val)
+ *     this.left = (left===undefined ? null : left)
+ *     this.right = (right===undefined ? null : right)
+ * }
+ */
+/**
+ * 993. Cousins in Binary Tree
+ * @param {TreeNode} root
+ * @param {number} x
+ * @param {number} y
+ * @return {boolean}
+ */
+const pushNode = (node) => {
+  const nextTree = [];
+  if (node.left) nextTree.push(node.left);
+  if (node.right) nextTree.push(node.right);
+  
+  return nextTree;
+}
+          
+const isCousins = function(root, x, y) {
+  const needVisit = [root];
+  
+  while (needVisit.length) {
+      if (needVisit.find((node) => x === node.val) && needVisit.find((node) => y === node.val)) {
+          result = true;
+      }
+      
+      const size = needVisit.length;
+      for (let i = 0; i < size; i++) {
+          const node = needVisit.shift();
+          
+          if (node.left && node.right) {
+              const hasSameParent = (node.left.val === x && node.right.val === y) || (node.right.val === x && node.left.val === y);
+              
+              if (hasSameParent) return false;
+          }
+          
+          const nextTree = pushNode(node);
+          if (nextTree.length) {
+              needVisit.push(...nextTree);    
+          }
+          
+      }
+  }
+  
+  return false;
+}

--- a/sujin-park/bfs-hash-table/groupAnagrams.js
+++ b/sujin-park/bfs-hash-table/groupAnagrams.js
@@ -1,0 +1,20 @@
+/**
+ * 49. Group Anagrams
+ * @param {string[]} strs
+ * @return {string[][]}
+ */
+const groupAnagrams = strs => {
+  const mapping = {};
+    
+  for (let str of strs) {
+    const sorted = str.split('').sort().join('');
+      
+    if(mapping[sorted] !== undefined) {
+      mapping[sorted].push(str);
+    } else {
+      mapping[sorted] = [str];
+    }
+  }
+    
+  return Object.values(mapping);
+};

--- a/sujin-park/bfs-hash-table/twoSum.js
+++ b/sujin-park/bfs-hash-table/twoSum.js
@@ -1,0 +1,22 @@
+/**
+ * 1. Two Sum
+ * @param {number[]} nums
+ * @param {number} target
+ * @return {number[]}
+ */
+const twoSum = function(nums, target) {
+  let result = [];
+  
+  for (let i = 0; i < nums.length; i++) {
+    const point = nums[i];
+    
+    for (let j = i + 1; j <= nums.length; j++) {
+      if (point + nums[j] === target) {
+        result = [i, j];
+        break;
+      }
+    }
+  }
+  
+  return result;
+};


### PR DESCRIPTION
## 문제 링크

https://leetcode.com/problems/cousins-in-binary-tree/
https://leetcode.com/problems/two-sum/
https://leetcode.com/problems/group-anagrams/

## 정리

https://www.notion.so/sjj92/6-BFS-Hash-Table-b3c1339e5eb348e0862f688cfe3d2c40

## 풀이 방식

**1. Two Sum**

1. n 번째 원소부터 순회를 한다.
2. n번째 원소를 point 로 할당하고, n + 1 번째 원소부터 마지막까지 순회한다.
3. point 와 nums[n + 1] 을 더했을 때 target 과 값이 같다면 결과 값에 할당하고 순회를 마친다.

**2. Cousins in Binary Tree**

1. 방문하지 않은 노드를 `needVisit` 라고 선언 및 root 를 할당한다.
2. `needVisit` 가 없을 때까지 방문한다.
3. 이번 tree depth 에 x 와 y 가 있으면 true 를 반환한다. (동일한 depth 에 있는 것이므로)
4. needVisit 길이를 size 에 할당한다.
5. 차례대로 needVisit 에 있는 첫번째 노드부터 순회한다.
6. 왼쪽과 오른쪽에 자식노드가 있다면 x 와 y 가 자식노드인지 체크하고 맞다면 같은 부모를 가지고 있으므로 false 를 반환한다.
7. 자식노드를 다시 needVisit 에 추가하고 3 - 6번을 반복한다.

자식노드를 비교하는 과정에서 풀리지않아서 솔루션을 보았습니다..

**3. Group Anagrams**

풀지 못했습니다....

풀이는 조금 더 추가하도록 하겠습니다!